### PR TITLE
Create python test action

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with pylint
+      run: |
+        pylint $(git ls-files '*.py')
+    - name: Test with pytest
+      run: |
+        pytest
+   


### PR DESCRIPTION
On Github, creating a chosen "Action" creates a "Workflow" (python-app.yml). It's configured to run pylint and pytest.

Essentially what is happening is on whatever trigger that is happening to the repository ("on:" tag, -> here the triggers are on any "push " action and any "pull_request" ) Github goes through .github/workflows/python-app.yml and runs a compose on it. On some GitHub server I suppose, it spins up a container that does the operations described in the .yml.

In this yml it is described to run a python container, install dependancies and run pytest and pylint.